### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Demos: [Vod点播](http://jackzhang1204.github.io/sewise/sewise_player/demos/vod
 
 
 
-####招聘：
-####帮现在公司高薪招H5高手要求掌握原生js、bootstratp、angularjs开发，熟悉移动端动态页面布局。如果合适请联系我微信：jackzhang1204（加微时说明下来意）希望有幸能和您一起共事。我们开发中的angularjs项目http://m.bihaohuo.cn
+#### 招聘：
+#### 帮现在公司高薪招H5高手要求掌握原生js、bootstratp、angularjs开发，熟悉移动端动态页面布局。如果合适请联系我微信：jackzhang1204（加微时说明下来意）希望有幸能和您一起共事。我们开发中的angularjs项目http://m.bihaohuo.cn
 
 
 ## What is Sewise Player?
@@ -352,7 +352,7 @@ Demos: [Vod点播](http://jackzhang1204.github.io/sewise/sewise_player/demos/vod
 ```
 例子：[demos/live_api.html](http://jackzhang1204.github.io/sewise/sewise_player/demos/live_api.html)
 
-###[更多例子](demos/例子说明.md)
+### [更多例子](demos/例子说明.md)
 
 
 ## Who is using Sewise Player?


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
